### PR TITLE
Add failure path unit tests

### DIFF
--- a/tests/test_account_service.py
+++ b/tests/test_account_service.py
@@ -4,6 +4,7 @@ import pandas as pd
 import uuid
 
 from services.account_service import create_accounts, suggest_name, create_account_name, create_accounts_batch
+from sqlalchemy.exc import SQLAlchemyError
 from database.models.accounts import Account, Tenant
 from database.models.currency import Currency
 from database.models.country import Country
@@ -74,6 +75,27 @@ class TestAccountCreator(unittest.TestCase):
         self.assertIn("account_id", df_result.columns)
         self.assertIn("wallet_id", df_result.columns)
         self.assertTrue(mock_notify.called)
+
+    @patch("services.account_service.suggest_name", return_value=None)
+    @patch("services.account_service.coolname.generate_slug", return_value="slug")
+    def test_create_account_name_failure(self, mock_slug, mock_suggest):
+        mock_session = MagicMock()
+        with self.assertRaises(ValueError):
+            create_account_name(mock_session, self.tenant)
+
+    @patch("services.account_service.create_wallets")
+    @patch("services.account_service.send_notification_create_account")
+    @patch("services.account_service.create_account_name")
+    def test_create_accounts_batch_failure(self, mock_name, mock_notify, mock_wallets):
+        mock_name.return_value = "user_test"
+        mock_wallets.return_value = [MagicMock()]
+        mock_session = MagicMock()
+        mock_session.commit.side_effect = SQLAlchemyError("db error")
+        mock_session.rollback = MagicMock()
+
+        create_accounts_batch(mock_session, self.df.copy(), self.currency, self.tenant)
+
+        self.assertTrue(mock_session.rollback.called)
 
 
 if __name__ == '__main__':

--- a/tests/test_wallet_service.py
+++ b/tests/test_wallet_service.py
@@ -8,13 +8,18 @@ from services.wallet_service import (
     get_wallet_by_account_id,
     create_wallets,
     create_wallets_batch,
-    get_integration_wallet_or_create
+    get_integration_wallet_or_create,
+    validate_funds,
+    add_funds_to_wallet,
+    subtract_funds_from_wallet
 )
 
 from database.models.wallets import Wallet
 from database.models.currency import Currency
 from database.models.accounts import Tenant
 from database.models.country import Country
+from sqlalchemy.exc import SQLAlchemyError
+from exceptions.insufficient_funds_error import InsufficientFundsError
 
 
 class TestWalletService(unittest.TestCase):
@@ -80,6 +85,28 @@ class TestWalletService(unittest.TestCase):
 
         wallet = get_integration_wallet_or_create(mock_session, self.tenant, self.currency)
         self.assertEqual(wallet, mock_wallet)
+
+    @patch("services.wallet_service.uuid.uuid4", return_value=uuid.UUID("87654321-4321-6789-4321-678987654321"))
+    def test_create_wallets_batch_failure(self, mock_uuid):
+        mock_session = MagicMock()
+        mock_session.commit.side_effect = SQLAlchemyError("db error")
+        mock_session.rollback = MagicMock()
+
+        create_wallets_batch(mock_session, self.df.copy(), self.currency)
+
+        self.assertTrue(mock_session.rollback.called)
+
+    def test_validate_funds_insufficient(self):
+        wallet = MagicMock(balance=10)
+        with self.assertRaises(InsufficientFundsError):
+            validate_funds(wallet, 20)
+
+    def test_add_and_subtract_funds_wallet(self):
+        wallet = MagicMock(balance=10)
+        wallet = add_funds_to_wallet(wallet, 5)
+        self.assertEqual(wallet.balance, 15)
+        wallet = subtract_funds_from_wallet(wallet, 3)
+        self.assertEqual(wallet.balance, 12)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend account service tests with error cases
- extend wallet service tests to cover rollback, fund validation and balance updates

## Testing
- `python -m unittest discover -s tests` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685b3f650d008320892e9346f66f6406